### PR TITLE
remove dockerfilepath from railway.json

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "builder": "DOCKERFILE",
-    "dockerfilePath": "Dockerfile"
+    "builder": "DOCKERFILE"
   },
   "deploy": {
     "startCommand": "/app/bin/server",


### PR DESCRIPTION
The root directory has already been set to backend so railway will automatically look for the Dockerfile in that directory.